### PR TITLE
Fix deprecation warnings for constants POWER_VOLT_AMPERE_REACTIVE, HassioServiceInfo and AREA_SQUARE_METERS

### DIFF
--- a/custom_components/bacnet_interface/config_flow.py
+++ b/custom_components/bacnet_interface/config_flow.py
@@ -7,7 +7,7 @@ from typing import Any
 import voluptuous as vol
 from aioecopanel import (DeviceDict, EcoPanelConnectionError,
                          EcoPanelEmptyResponseError, Interface)
-from homeassistant.components.hassio import HassioServiceInfo
+from homeassistant.helpers.service_info.hassio import HassioServiceInfo
 from homeassistant.config_entries import (CONN_CLASS_LOCAL_PUSH, ConfigEntry,
                                           ConfigFlow, ConfigFlowResult,
                                           OptionsFlow)

--- a/custom_components/bacnet_interface/helper.py
+++ b/custom_components/bacnet_interface/helper.py
@@ -489,7 +489,7 @@ def bacnet_to_ha_units(unit_in: str | None) -> str | None:
         case "squareInches":
             return None
         case "squareMeters":
-            return UnitOfArea.AREA_SQUARE_METERS
+            return UnitOfArea.SQUARE_METERS
         case "squareMetersPerNewton":
             return None
         case "teslas":

--- a/custom_components/bacnet_interface/helper.py
+++ b/custom_components/bacnet_interface/helper.py
@@ -6,8 +6,7 @@ from logging import BASIC_FORMAT
 
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import (AREA_SQUARE_METERS,
-                                 CONCENTRATION_MICROGRAMS_PER_CUBIC_FOOT,
+from homeassistant.const import (CONCENTRATION_MICROGRAMS_PER_CUBIC_FOOT,
                                  CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
                                  CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
                                  CONCENTRATION_PARTS_PER_BILLION,
@@ -17,6 +16,7 @@ from homeassistant.const import (AREA_SQUARE_METERS,
                                  LIGHT_LUX, PERCENTAGE,
                                  POWER_VOLT_AMPERE_REACTIVE,
                                  REVOLUTIONS_PER_MINUTE, UnitOfApparentPower,
+                                 UnitOfArea,
                                  UnitOfElectricCurrent,
                                  UnitOfElectricPotential, UnitOfEnergy,
                                  UnitOfFrequency, UnitOfInformation,
@@ -489,7 +489,7 @@ def bacnet_to_ha_units(unit_in: str | None) -> str | None:
         case "squareInches":
             return None
         case "squareMeters":
-            return AREA_SQUARE_METERS
+            return UnitOfArea.AREA_SQUARE_METERS
         case "squareMetersPerNewton":
             return None
         case "teslas":

--- a/custom_components/bacnet_interface/helper.py
+++ b/custom_components/bacnet_interface/helper.py
@@ -14,7 +14,6 @@ from homeassistant.const import (CONCENTRATION_MICROGRAMS_PER_CUBIC_FOOT,
                                  CONCENTRATION_PARTS_PER_MILLION,
                                  CURRENCY_DOLLAR, CURRENCY_EURO, DEGREE,
                                  LIGHT_LUX, PERCENTAGE,
-                                 POWER_VOLT_AMPERE_REACTIVE,
                                  REVOLUTIONS_PER_MINUTE, UnitOfApparentPower,
                                  UnitOfArea,
                                  UnitOfElectricCurrent,
@@ -22,8 +21,9 @@ from homeassistant.const import (CONCENTRATION_MICROGRAMS_PER_CUBIC_FOOT,
                                  UnitOfFrequency, UnitOfInformation,
                                  UnitOfIrradiance, UnitOfLength, UnitOfMass,
                                  UnitOfPower, UnitOfPrecipitationDepth,
-                                 UnitOfPressure, UnitOfSoundPressure,
-                                 UnitOfSpeed, UnitOfTemperature, UnitOfTime,
+                                 UnitOfPressure, UnitOfReactivePower,
+                                 UnitOfSoundPressure, UnitOfSpeed,
+                                 UnitOfTemperature, UnitOfTime,
                                  UnitOfVolume, UnitOfVolumeFlowRate,
                                  UnitOfVolumetricFlux)
 
@@ -513,7 +513,7 @@ def bacnet_to_ha_units(unit_in: str | None) -> str | None:
         case "voltAmpereHours":
             return None
         case "voltAmpereHoursReactive":
-            return POWER_VOLT_AMPERE_REACTIVE
+            return UnitOfReactivePower.VOLT_AMPERE_REACTIVE
         case "voltAmperes":
             return None
         case "voltAmperesReactive":


### PR DESCRIPTION
Addresses the deprecation warnings for constants:
- `POWER_VOLT_AMPERE_REACTIVE`, removed in HA Core 2025.9
- `HassioServiceInfo`, to be removed in HA Core 2025.11
- `AREA_SQUARE_METERS`, to be removed in HA Core 2025.12

Fixes #41